### PR TITLE
Modify split to handle values containing '='

### DIFF
--- a/resolvers.py
+++ b/resolvers.py
@@ -11,7 +11,7 @@ def vk_streams(html):
     params = flashvars.split('&amp;')
     formats = []
     for param in params:
-        key, value = param.split('=')
+        key, value = param.split('=',1)
         if key.startswith('url'):
             formats.append((key, value))
     return formats


### PR DESCRIPTION
If param contains more than one '=' the split will return error. E.g:
url240=http://cs540403v4.vk.me/u01234/videos/blabla.mp4?extra=ZIH4SI05-2Gsds

File "/xyz/plugin.video.dreamfilm/resolvers.py", line 18, in vk_streams
                                            key, value = param.split('=')
                                            ValueError: too many values to unpack