### PR TITLE
Add subtitles

### DIFF
--- a/dreamfilm.py
+++ b/dreamfilm.py
@@ -105,6 +105,10 @@ def streams_from_player_url(url):
     return [('video', url)]
 
 
+def subtitles_from_url(url):
+    return re.findall('&c\d+_file=(?P<url>[^&]+)', url)
+
+
 def _search_url(q, page=0):
     offset = page * ITEMS_PER_PAGE
     return API_BASE_URL + ('?q=%s&type=list&offset=%d&limit=%d' % (q, offset, ITEMS_PER_PAGE))

--- a/navigation.py
+++ b/navigation.py
@@ -162,23 +162,26 @@ class Navigation(object):
         try:
             players = json.loads(players_data)
             streams = dreamfilm.streams_from_player_url(players[0]['url'])
-            return self.select_stream(title, streams)
+            subtitles = dreamfilm.subtitles_from_url(players[0]['url'])
+            return self.select_stream(title, streams, subtitles)
         except Exception, e:
             print str(e)
             dialog = self.xbmcgui.Dialog()
             dialog.ok("Error", "Failed to open stream")
 
-    def select_stream(self, title, streams):
+    def select_stream(self, title, streams, subtitles):
 
         # Ask user which stream to use
         url = self.quality_select_dialog(streams)
         if url is None:
             return
-        return self.play_stream(title, url)
+        return self.play_stream(title, url, subtitles)
 
-    def play_stream(self, title, stream):
+    def play_stream(self, title, stream, subtitles):
         li = self.xbmcgui.ListItem(label=title, path=stream)
         li.setInfo(type='Video', infoLabels={"Title": title})
+        li.setSubtitles(subtitles)
+
         return self.xbmc.Player().play(item=stream, listitem=li)
 
     def list_movie_parts(self, title, players_data):
@@ -202,7 +205,8 @@ class Navigation(object):
     def play_movie_part(self, title, player_url):
         try:
             streams = dreamfilm.streams_from_player_url(player_url)
-            return self.select_stream(title, streams)
+            subtitles = dreamfilm.subtitles_from_url(player_url)
+            return self.select_stream(title, streams, subtitles)
         except Exception, e:
             dialog = self.xbmcgui.Dialog()
             print 'EEEE'
@@ -213,8 +217,9 @@ class Navigation(object):
         try:
             streams = dreamfilm.streams_from_player_url(url)
 
+            subtitles = dreamfilm.subtitles_from_url(url)
             name = '%s S%sE%s' % (title, season_number, episode_number)
-            return self.select_stream(name, streams)
+            return self.select_stream(name, streams, subtitles)
         except Exception, e:
             print 'EEEE'
             print str(e)

--- a/tests.py
+++ b/tests.py
@@ -31,6 +31,34 @@ class ParseTests(unittest.TestCase):
             self.assertEqual(len(formats), 2)
 
 
+class SubtitleTests(unittest.TestCase):
+
+    def test_empty_string_gives_no_subtitles(self):
+        answer = dreamfilm.subtitles_from_url('')
+        self.assertEqual(answer, [])
+
+    def test_single_subtitle(self):
+        url = 'http://url.com?cap&c1_file=http://sub1.vtt&c1_label=Svenska'
+        expected = ['http://sub1.vtt']
+        actual = dreamfilm.subtitles_from_url(url)
+        self.assertEqual(expected, actual)
+
+    def test_subtitle_with_high_number(self):
+        url = 'http://url.com?cap&c123_file=http://sub1.vtt&c1_label=Svenska'
+        expected = ['http://sub1.vtt']
+        actual = dreamfilm.subtitles_from_url(url)
+        self.assertEqual(expected, actual)
+
+    def test_multiple_subtitles(self):
+        url = 'http://url.com&c1_file=http://sub1.vtt&c1_label=English&c2_file=http://sub2.vtt&c2_label=Svenska&c3_file=http://sub3.vtt&c3_label=Suomi'
+        actual = dreamfilm.subtitles_from_url(url)
+        expected = []
+        expected.append('http://sub1.vtt')
+        expected.append('http://sub2.vtt')
+        expected.append('http://sub3.vtt')
+        self.assertEqual(expected, actual)
+
+
 class APITests(unittest.TestCase):
 
     def test_parse_apirespone(self):


### PR DESCRIPTION
It seems most new streams are added without embedded subtitles. Instead, the url to the streams have subtitle links in them. This commit parses the subtitles urls, and passes them on to Kodi. In most cases, there is only one subtitle available (usually Swedish). In the few cases there are more than one, the user has no idea which subtitle is in which language. This is because Kodi recognizes subtitles by the name of the subtitles, which is expected to be on the form some_path.language_in_english.vtt (other extensions are also possible I believe). That leaves trial and error to select the subtitle to the prefered language for the user, but since this is the rare case, I didn't consider it worth to do something about now.

To test, take for example GoT S5E2 (or any GoT S5 episode if the Picasa pull request is merged first :) ). For a video with more than one subtitle, see for example Sword of Vengeance (it doesn't run in the browser either, but you can hardcode the link and open a different stream, and you'll see you can choose the subtitles in Kodi).

Blev några pull requests, men de borde gå att merga utan konflikter (eller möjligtvis triviala konflikter).