### PR TITLE
Sort numeric strings properly

### DIFF
--- a/dreamfilm.py
+++ b/dreamfilm.py
@@ -122,7 +122,7 @@ def _series_to_list(json_data, serie_id):
     seasons = []
     current_episodes = []
 
-    for item in sorted(response['data'], key=lambda x: x['season']):
+    for item in sorted(response['data'], key=lambda x: natural_sort_key(x['season'])):
         episode = Episode(item['id'], item['season'], item['episode'], item['url'])
         if last_season and episode.season != last_season:
             seasons.append(_make_season(serie_id, current_episodes))

--- a/dreamfilm.py
+++ b/dreamfilm.py
@@ -134,7 +134,7 @@ def _series_to_list(json_data, serie_id):
 
 
 def _make_season(serie_id, episodes):
-    return Season(serie_id, episodes[0].season, sorted(episodes, key=lambda x: x.episode))
+    return Season(serie_id, episodes[0].season, sorted(episodes, key=lambda x: natural_sort_key(x.episode)))
 
 def _api_request(url):
     opener = urllib2.build_opener()

--- a/dreamfilm.py
+++ b/dreamfilm.py
@@ -175,5 +175,9 @@ def _head_request(url):
     response = urllib2.urlopen(request)
     print response.info()
 
+def natural_sort_key(s, _nsre=re.compile('([0-9]+)')):
+    return [int(text) if text.isdigit() else text.lower()
+            for text in re.split(_nsre, s)]
+
 if __name__ == '__main__':
     print search('abba');

--- a/navigation.py
+++ b/navigation.py
@@ -281,14 +281,15 @@ class Navigation(object):
         return self.xbmcplugin.endOfDirectory(self.handle)
 
     def quality_select_dialog(self, stream_urls):
-        qualities = [s[0] for s in stream_urls]
+        sorted_urls = sorted(stream_urls, key=lambda s: dreamfilm.natural_sort_key(s[0]))
+        qualities = [s[0] for s in sorted_urls]
         dialog = self.xbmcgui.Dialog()
         answer = 0
         if len(qualities) > 1:
             answer = dialog.select("Quality Select", qualities)
             if answer == -1:
                 return
-        url = stream_urls[answer][1]
+        url = sorted_urls[answer][1]
         return url
 
     def dispatch(self):

--- a/tests.py
+++ b/tests.py
@@ -64,7 +64,6 @@ class SubtitleTests(unittest.TestCase):
         expected.append('http://sub3.vtt')
         self.assertEqual(expected, actual)
 
-
 class APITests(unittest.TestCase):
 
     def test_parse_apirespone(self):
@@ -91,6 +90,33 @@ class APITests(unittest.TestCase):
         page2 = 'http://www.dreamfilmhd.org/API/api.php?type=list&offset=50&limit=25&q=Bad%20santa&sort=alpha'
         self.assertEqual(pager(1), page1)
         self.assertEqual(pager(2), page2)
+
+
+class SortTests(unittest.TestCase):
+
+    def tearDown(self):
+        actual = sorted(self.input, key=dreamfilm.natural_sort_key)
+        self.assertEqual(self.expected, actual)
+
+    def test_alphabetical(self):
+        self.input = ['foo', 'bar', 'baz']
+        self.expected = ['bar', 'baz', 'foo']
+
+    def test_numbers(self):
+        self.input = ['number_12', 'number_4', 'number_0']
+        self.expected = ['number_0', 'number_4', 'number_12']
+
+    def test_leading_numbers(self):
+        self.input = ['1080p', '720p', '240p', '360p', '480p']
+        self.expected = ['240p', '360p', '480p', '720p', '1080p']
+
+    def test_mixed_leading_zeros(self):
+        self.input = ['Season 02', 'Season 000010', 'Season 1']
+        self.expected = ['Season 1', 'Season 02', 'Season 000010']
+
+    def test_sorting_mixed_cases_preserves_order(self):
+        self.input = ['b', 'B', 'A', 'a']
+        self.expected = ['A', 'a', 'b', 'B']
 
 
 if __name__ == '__main__':

--- a/tests.py
+++ b/tests.py
@@ -131,9 +131,9 @@ class QualitySelectTests(unittest.TestCase):
 
     def test_unsorted_input(self):
         self.input = [("1080p", "url_1080"), ('720p', 'url_720')]
-        self.dialog_arg = ["1080p", "720p"]
+        self.dialog_arg = ["720p", "1080p"]
         self.dialog.select.return_value = 1
-        self.expected = "url_720"
+        self.expected = "url_1080"
 
 
 class SortTests(unittest.TestCase):


### PR DESCRIPTION
Sometimes, pythons built in sort does not sort in the order a human would find natural, especially with strings containing numbers. In particular, I have observed this in the quality select dialog, where the order of the qualities have been mixed (e.g., 480, 360, 720, see e.g. Mad Max - fury road, or Terminator - Genisys), so add a sort key that sorts these in the natural order.
This has the drawback that if something other than numeric values are seen their order will be wrong (e.g. if the qualities are shown as "Full", "Hd", "Poor"), but that shouldn't occur...