### PR TITLE
Subtitle missing http

### DIFF
--- a/dreamfilm.py
+++ b/dreamfilm.py
@@ -108,7 +108,14 @@ def streams_from_player_url(url):
 
 
 def subtitles_from_url(url):
-    return re.findall('&c\d+_file=(?P<url>[^&]+)', url)
+    subs = re.findall('&c\d+_file=(?P<url>[^&]+)', url)
+
+    for idx, s in enumerate(subs):
+        if '://' not in s:
+            # No protocol given, assume http
+            subs[idx] = 'http://' + s
+
+    return subs
 
 
 def _search_url(q, page=0):

--- a/tests.py
+++ b/tests.py
@@ -39,30 +39,25 @@ class ParseTests(unittest.TestCase):
 
 class SubtitleTests(unittest.TestCase):
 
+    def tearDown(self):
+        actual = dreamfilm.subtitles_from_url(self.url)
+        self.assertEqual(self.expected, actual)
+
     def test_empty_string_gives_no_subtitles(self):
-        answer = dreamfilm.subtitles_from_url('')
-        self.assertEqual(answer, [])
+        self.url = ''
+        self.expected = []
 
     def test_single_subtitle(self):
-        url = 'http://url.com?cap&c1_file=http://sub1.vtt&c1_label=Svenska'
-        expected = ['http://sub1.vtt']
-        actual = dreamfilm.subtitles_from_url(url)
-        self.assertEqual(expected, actual)
+        self.url = 'http://url.com?cap&c1_file=http://sub1.vtt&c1_label=Svenska'
+        self.expected = ['http://sub1.vtt']
 
     def test_subtitle_with_high_number(self):
-        url = 'http://url.com?cap&c123_file=http://sub1.vtt&c1_label=Svenska'
-        expected = ['http://sub1.vtt']
-        actual = dreamfilm.subtitles_from_url(url)
-        self.assertEqual(expected, actual)
+        self.url = 'http://url.com?cap&c123_file=http://sub1.vtt&c1_label=Svenska'
+        self.expected = ['http://sub1.vtt']
 
     def test_multiple_subtitles(self):
-        url = 'http://url.com&c1_file=http://sub1.vtt&c1_label=English&c2_file=http://sub2.vtt&c2_label=Svenska&c3_file=http://sub3.vtt&c3_label=Suomi'
-        actual = dreamfilm.subtitles_from_url(url)
-        expected = []
-        expected.append('http://sub1.vtt')
-        expected.append('http://sub2.vtt')
-        expected.append('http://sub3.vtt')
-        self.assertEqual(expected, actual)
+        self.url = 'http://url.com&c1_file=http://sub1.vtt&c1_label=English&c2_file=http://sub2.vtt&c2_label=Svenska&c3_file=http://sub3.vtt&c3_label=Suomi'
+        self.expected = ['http://sub1.vtt', 'http://sub2.vtt', 'http://sub3.vtt']
 
 
 class APITests(unittest.TestCase):

--- a/tests.py
+++ b/tests.py
@@ -59,6 +59,10 @@ class SubtitleTests(unittest.TestCase):
         self.url = 'http://url.com&c1_file=http://sub1.vtt&c1_label=English&c2_file=http://sub2.vtt&c2_label=Svenska&c3_file=http://sub3.vtt&c3_label=Suomi'
         self.expected = ['http://sub1.vtt', 'http://sub2.vtt', 'http://sub3.vtt']
 
+    def test_missing_http(self):
+        self.url = 'http://url.com&c1_file=sub1.vtt&c1_label=English&c2_file=sub2.vtt&c2_label=Svenska&c3_file=sub3.vtt&c3_label=Suomi'
+        self.expected = ['http://sub1.vtt', 'http://sub2.vtt', 'http://sub3.vtt']
+
 
 class APITests(unittest.TestCase):
 


### PR DESCRIPTION
It was observed that in a few cases (or at least once, Terminator Genisys), subtitle urls do not start with http://, which confuses Kodi. So add a check for that.
I don't really like these sort of "fixes", but I didn't come up with a better idea...